### PR TITLE
Remove MAD Akka Http Content Length Limit

### DIFF
--- a/build/config/mad/config.conf
+++ b/build/config/mad/config.conf
@@ -15,5 +15,6 @@ akkaConfiguration {
     stdout-loglevel = "DEBUG"
     logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
     actor.debug.unhandled = "on"
+    http.server.parsing.max-content-length="infinite"
   }
 }

--- a/demo/config/mad/config.conf
+++ b/demo/config/mad/config.conf
@@ -15,5 +15,6 @@ akkaConfiguration {
     stdout-loglevel = "DEBUG"
     logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
     actor.debug.unhandled = "on"
+    http.server.parsing.max-content-length="infinite"
   }
 }


### PR DESCRIPTION
Disable the 8 MB default server side content length limit for MAD in both demo and build stack configurations.