### PR TITLE
Fix classpath issues (com.inscopemetrics -> io.inscopemetrics)

### DIFF
--- a/build/config/mad/pipelines/pipeline.conf
+++ b/build/config/mad/pipelines/pipeline.conf
@@ -25,11 +25,11 @@ gaugeStatistics = [
 ]
 sources = [
   {
-    type = "com.inscopemetrics.mad.sources.ClientHttpSourceV2"
+    type = "io.inscopemetrics.mad.sources.ClientHttpSourceV2"
     name = "http_source_v2"
   },
   {
-    type="com.inscopemetrics.mad.sources.MappingSource"
+    type="io.inscopemetrics.mad.sources.MappingSource"
     name="collectd_mapping_source"
     "findAndReplace": {
       "^cpu/([\\d]+)/(cpu|percent)/([^/]+)(/value)?": ["cpu/$3", "cpu/by_core/$1/$3"],
@@ -64,19 +64,19 @@ sources = [
       "^uptime/uptime(/value)?": ["uptime/value"]
     },
     "source": {
-      type="com.inscopemetrics.mad.sources.CollectdHttpSourceV1"
+      type="io.inscopemetrics.mad.sources.CollectdHttpSourceV1"
       name="collectd_http_source"
     }
   },
   {
-    type="com.inscopemetrics.mad.sources.MappingSource"
+    type="io.inscopemetrics.mad.sources.MappingSource"
     name="graphite_plaintext_tcp_mapping_source"
     findAndReplace={
       "\\."=["/"]
     }
     source={
       ## The source type (required)
-      type="com.inscopemetrics.mad.sources.GraphitePlaintextTcpSource"
+      type="io.inscopemetrics.mad.sources.GraphitePlaintextTcpSource"
 
       ## Interface to bind to (optional, defaults to localhost)
       host="0.0.0.0"
@@ -101,14 +101,14 @@ sources = [
     }
   }
   {
-    type="com.inscopemetrics.mad.sources.MappingSource"
+    type="io.inscopemetrics.mad.sources.MappingSource"
     name="telegraf_json_tcp_mapping_source"
     findAndReplace={
       "\\."=["/"]
     }
     source={
       ## The source type (required)
-      type="com.inscopemetrics.mad.sources.TelegrafJsonTcpSource"
+      type="io.inscopemetrics.mad.sources.TelegrafJsonTcpSource"
 
       ## Interface to bind to (optional, defaults to localhost)
       host="0.0.0.0"
@@ -135,20 +135,20 @@ sources = [
 ]
 sinks = [
   {
-    type = "com.inscopemetrics.mad.sinks.PeriodicStatisticsSink"
+    type = "io.inscopemetrics.mad.sinks.PeriodicStatisticsSink"
     name = "http_periodic_statistics_sink"
     intervalInMilliseconds = "1000"
   },
   {
-    type = "com.inscopemetrics.mad.sinks.PeriodFilteringSink"
+    type = "io.inscopemetrics.mad.sinks.PeriodFilteringSink"
     name = "period_filtering_http_telemetry_sink"
     excludeGreaterThan = "PT1S"
     sink = {
-      type = "com.inscopemetrics.mad.sinks.TimeThresholdSink"
+      type = "io.inscopemetrics.mad.sinks.TimeThresholdSink"
       name = "time_threshold_http_telemetry_sink"
       threshold = "PT10M"
       sink = {
-        type = "com.inscopemetrics.mad.sinks.TelemetrySink"
+        type = "io.inscopemetrics.mad.sinks.TelemetrySink"
         name = "http_telemetry_sink"
         histogramStatistics = [
           "median",
@@ -160,15 +160,15 @@ sinks = [
     }
   },
   {
-    type = "com.inscopemetrics.mad.sinks.PeriodFilteringSink"
+    type = "io.inscopemetrics.mad.sinks.PeriodFilteringSink"
     name = "period_filtering_http_cluster_sink"
     excludeLessThan = "PT1M"
     sink = {
-      type = "com.inscopemetrics.mad.sinks.TimeThresholdSink"
+      type = "io.inscopemetrics.mad.sinks.TimeThresholdSink"
       name = "time_threshold_http_cluster_sink"
       threshold = "PT10M"
       sink = {
-        type = "com.inscopemetrics.mad.sinks.AggregationServerHttpSink"
+        type = "io.inscopemetrics.mad.sinks.AggregationServerHttpSink"
         name = "http_cluster_sink"
         uri = "http://localhost:7066/metrics/v1/data/persist"
         #uri = "http://localhost:7066/metrics/v1/data/reaggregate"


### PR DESCRIPTION
To correctly match the classpaths found in https://github.com/ArpNetworking/metrics-aggregator-daemon/tree/master-2.0/src/main/java/io/inscopemetrics/mad

Before this change we would see classpath errors on startup similar to 
```
[ERROR] io.inscopemetrics.mad.configuration.jackson.DynamicConfiguration : name="log", message="Validation of offered configuration failed",
...
Caused by: com.fasterxml.jackson.databind.exc.InvalidTypeIdException: Could not resolve type id 'com.inscopemetrics.mad.sinks.PeriodicStatisticsSink' as a subtype of [simple type, class io.inscopemetrics.mad.sinks.Sink]: no such class found
 at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: io.inscopemetrics.mad.configuration.PipelineConfiguration$Builder["sinks"]->java.util.ArrayList[0])
```