### PR TITLE
Fix the -i argument by moving automatic calculation to after when options are evaluated

### DIFF
--- a/build/start.sh
+++ b/build/start.sh
@@ -69,11 +69,6 @@ elif command -v dig > /dev/null; then
   host_ip_address=$(dig +short `hostname -f`)
 fi
 
-if [ -z "${host_ip_address}" ]; then
-  printf "\e[0;31mError\e[0m: Unable to determine local ip address; please add the argument '-i <address>'\n"
-  exit 1
-fi
-
 target="${dir}/../target"
 mkdir -p "${target}"
 
@@ -313,6 +308,11 @@ while getopts ":h?vnpacs:t:i:" opt; do
       ;;
   esac
 done
+
+if [ -z "${host_ip_address}" ]; then
+  printf "\e[0;31mError\e[0m: Unable to determine local ip address; please add the argument '-i <address>'\n"
+  exit 1
+fi
 
 if [ -n "${verbose}" ]; then
   printf "services = ${services[@]}\n"


### PR DESCRIPTION
In the current code, the `-i` arg is always ignored. 

The evaluation of all arguments comes after the code that checks to see if `host_ip_address` has a non-empty value.

To fix that, moved the block later in the file.

Tested manually via `./start.sh -ap -i "my.ip.was.here"`